### PR TITLE
Include unistd.h such that sleep and usleep can be resolved.

### DIFF
--- a/src/eventracer/trialwebapp/WebRaceAnalyzer.cpp
+++ b/src/eventracer/trialwebapp/WebRaceAnalyzer.cpp
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <errno.h>
 #include <sys/stat.h>

--- a/src/eventracer/webapp/RaceAnalyzerMain.cpp
+++ b/src/eventracer/webapp/RaceAnalyzerMain.cpp
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "gflags/gflags.h"
 


### PR DESCRIPTION
The unistd.h include directives are necessary to successfully compile eventracer on my 64-bit Ubuntu 13.10 machine.
